### PR TITLE
Compatibility with JasperReports Server 7.1 (with latest hotfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Domain-Metadata-Modifier
 
+See this article on the Jaspersoft Community Wiki for further details and related YouTube videos: https://community.jaspersoft.com/wiki/cascading-domain-changes-through-ad-hoc-topics-views-reports-and-dashboards
+
 This project is for commercial users of TIBCO JasperReports Server who wish to make domain changes. A major drawback of using domains is that making changes to a domain that contains dependent repository objects (such as Ad Hoc views, reports and dashboards) would often cause those objects to break. Users would then need to recreate the Ad Hoc views, dashboards, etc. This tool is aimed at two specific use cases:
 
 * Removing one or more existing fields from a domain and its dependent Ad Hoc views, reports and dashboards

--- a/metadata/Common.py
+++ b/metadata/Common.py
@@ -84,7 +84,7 @@ class Common():
     REST_V2 = 'rest_v2'
     J_USERNAME = 'j_username'
     J_PASSWORD = 'j_password'
-    LOGIN_PATH = REPO_PATH_SEPARATOR + 'rest' + REPO_PATH_SEPARATOR + 'login'
+    LOGIN_PATH = REPO_PATH_SEPARATOR + REST_V2 + REPO_PATH_SEPARATOR + 'login'
     EXPORT = 'export'
     EXPORT_START_PATH = REPO_PATH_SEPARATOR + REST_V2 + REPO_PATH_SEPARATOR + EXPORT + REPO_PATH_SEPARATOR
     IMPORT = 'import'


### PR DESCRIPTION
Updated Common.py to use rest_v2 for login.
The rest_v2/login endpoint is now required to work with JasperReports Server 7.1 (with latest hotfix) and later. Further details: https://community.jaspersoft.com/wiki/rest-v2-login-service